### PR TITLE
Leading zero table or column

### DIFF
--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -2,7 +2,7 @@ name: CI DEV Test
 
 on:
   push:
-    branches: ["feat/*/*"]
+    branches: ["feat/*/*","fix/*/*"]
 
 jobs:
   test:

--- a/src/Helpers/StringHelper.php
+++ b/src/Helpers/StringHelper.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace TYGHaykal\LaravelSeedGenerator\Helpers;
 
 use Illuminate\Console\Command;
@@ -18,7 +19,9 @@ class StringHelper
             if (is_string($value) && preg_match("/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z/", $value)) {
                 $value = \Carbon\Carbon::parse($value)->format("Y-m-d H:i:s");
             }
-            if (is_numeric($value) && intval($value) == $value) {
+            // Only convert to integer if it's a pure numeric value (not a string that starts with numbers)
+            // This prevents table/column names like "000_users" or "0name" from being converted to integers
+            if (is_numeric($value) && intval($value) == $value && !is_string($value)) {
                 $value = intval($value);
             }
             $prettyValue = var_export($value, true);

--- a/src/Helpers/StringHelper.php
+++ b/src/Helpers/StringHelper.php
@@ -21,15 +21,13 @@ class StringHelper
             }
             // Only convert to integer if it's a pure numeric value
             // But preserve leading zeros in identifiers (table/column names) by checking if the key suggests it's an identifier
-            // Identifiers typically have underscores, start with letters, or contain special characters
-            $isIdentifier = is_string($key) && (
-                strpos($key, '_') !== false ||
-                preg_match('/^[a-zA-Z]/', $key) ||
-                preg_match('/^[0-9]+[a-zA-Z_]/', $key) ||
-                preg_match('/^[0-9]+_[a-zA-Z]/', $key)
+            // Identifiers with leading zeros typically start with one or more zeros followed by letters or underscores
+            $isLeadingZeroIdentifier = is_string($key) && (
+                preg_match('/^0+[a-zA-Z_]/', $key) ||  // 0name, 00_column, 000_test
+                preg_match('/^0+$/', $key)             // 0, 00, 000 (pure zero identifiers)
             );
 
-            if (is_numeric($value) && intval($value) == $value && !$isIdentifier) {
+            if (is_numeric($value) && intval($value) == $value && !$isLeadingZeroIdentifier) {
                 $value = intval($value);
             }
             $prettyValue = var_export($value, true);

--- a/src/Helpers/StringHelper.php
+++ b/src/Helpers/StringHelper.php
@@ -23,12 +23,12 @@ class StringHelper
             // But preserve leading zeros in identifiers (table/column names) by checking if the key suggests it's an identifier
             // Identifiers typically have underscores, start with letters, or contain special characters
             $isIdentifier = is_string($key) && (
-                strpos($key, '_') !== false || 
-                preg_match('/^[a-zA-Z]/', $key) || 
+                strpos($key, '_') !== false ||
+                preg_match('/^[a-zA-Z]/', $key) ||
                 preg_match('/^[0-9]+[a-zA-Z_]/', $key) ||
                 preg_match('/^[0-9]+_[a-zA-Z]/', $key)
             );
-            
+
             if (is_numeric($value) && intval($value) == $value && !$isIdentifier) {
                 $value = intval($value);
             }

--- a/src/Helpers/StringHelper.php
+++ b/src/Helpers/StringHelper.php
@@ -19,9 +19,17 @@ class StringHelper
             if (is_string($value) && preg_match("/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z/", $value)) {
                 $value = \Carbon\Carbon::parse($value)->format("Y-m-d H:i:s");
             }
-            // Only convert to integer if it's a pure numeric value (not a string that starts with numbers)
-            // This prevents table/column names like "000_users" or "0name" from being converted to integers
-            if (is_numeric($value) && intval($value) == $value && !is_string($value)) {
+            // Only convert to integer if it's a pure numeric value
+            // But preserve leading zeros in identifiers (table/column names) by checking if the key suggests it's an identifier
+            // Identifiers typically have underscores, start with letters, or contain special characters
+            $isIdentifier = is_string($key) && (
+                strpos($key, '_') !== false || 
+                preg_match('/^[a-zA-Z]/', $key) || 
+                preg_match('/^[0-9]+[a-zA-Z_]/', $key) ||
+                preg_match('/^[0-9]+_[a-zA-Z]/', $key)
+            );
+            
+            if (is_numeric($value) && intval($value) == $value && !$isIdentifier) {
                 $value = intval($value);
             }
             $prettyValue = var_export($value, true);


### PR DESCRIPTION
#38 

This pull request improves the handling of table and column names with leading zeros in the seed generator, ensuring that identifiers with leading zeros are preserved as strings and not inadvertently converted to integers. It also adds comprehensive tests to verify this behavior. Additionally, the CI workflow is updated to include fix branches.

**Seed generator improvements:**

* Updated `StringHelper::prettyPrintArray` to detect and preserve leading zeros in table and column names, preventing them from being converted to integers and ensuring correct string representation in generated seeders.

**Testing enhancements:**

* Added two new test cases in `TableCommandTest.php` to verify that table and column names with leading zeros are preserved correctly in the generated seeder files, and that values are properly typed.

**CI workflow update:**

* Modified `.github/workflows/dev-test.yml` to trigger the CI on both feature and fix branches, improving test coverage for more branch types.

**Code style improvements:**

* Added a blank line after the PHP opening tag in `StringHelper.php` and `TableCommandTest.php` for better code style consistency. [[1]](diffhunk://#diff-517436cbe9997e56ffd2b88edfa86ff9e7312ae661ba86133271f97101bbf2bfR2) [[2]](diffhunk://#diff-7443e3603240bc1cb8f9c29f9ee168b19645f828a199628f7ce382f9de96de34R2)